### PR TITLE
Manually implement Tabled for Consumer

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -626,7 +626,7 @@ impl<'a> Client<'a> {
 
         let bs: Vec<&BindingInfo> = bindings
             .iter()
-            .filter(|b| b.source == source && b.routing_key == routing_key && b.arguments == args)
+            .filter(|b| b.source == source && b.routing_key == routing_key && b.arguments.0 == args)
             .collect();
         match bs.len() {
             0 => Err(Error::NotFound()),


### PR DESCRIPTION
So that we can list consumer queue and virtual host even though the API returns them as a nested document.