### PR TITLE
`node` field is missing just after declaration

### DIFF
--- a/src/responses.rs
+++ b/src/responses.rs
@@ -399,6 +399,7 @@ pub struct QueueInfo {
     #[tabled(skip)]
     pub arguments: XArguments,
 
+    #[serde(default = "undefined")]
     pub node: String,
     #[serde(default)]
     pub state: String,
@@ -631,4 +632,8 @@ pub struct QuorumEndangeredQueue {
     pub vhost: String,
     #[serde(rename(deserialize = "type"))]
     pub queue_type: String,
+}
+
+fn undefined() -> String {
+    "?".to_string()
 }


### PR DESCRIPTION
Without this change, we get an error when performing `list queues` while queues are being declared:
`error decoding response body: missing field `node``

The question is what value should be used - `?` is short, which should help if we want to print many columns, but I'm open to `undefined` or something else.