### PR TITLE
Remove zeroed sockets_total

### DIFF
--- a/src/responses.rs
+++ b/src/responses.rs
@@ -502,7 +502,6 @@ pub struct ClusterNode {
     pub fd_total: u32,
     #[serde(rename(deserialize = "proc_total"))]
     pub total_erlang_processes: u32,
-    pub sockets_total: u32,
     #[serde(rename(deserialize = "mem_limit"))]
     pub memory_high_watermark: u64,
     #[serde(rename(deserialize = "mem_alarm"))]


### PR DESCRIPTION
Value is zeroed following partial removal of the FHC.

I don't know what I'm doing for what it's worth.