### PR TITLE
Adapt responses::Connection for direct connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Rust Client for the RabbitMQ HTTP API Change Log
 
-## v0.36.0 (in development)
+## v0.37.0 (in development)
 
 No changes yet.
 
 
+## v0.36.0 (Jul 4, 2025)
+
+### Enhancements
+
+ * `response::Connection` now can represent direct connections,
+   a special kind of connections supported by the Erlang AMQP 0-9-1 client,
+   that shovels and federation links use when connecting to the local
+   node.
+
+   GitHub issues: [rabbitmq/rabbitmqadmin-ng#68](https://github.com/rabbitmq/rabbitmqadmin-ng/issues/68), [#61](https://github.com/michaelklishin/rabbitmq-http-api-rs/pull/61)
+
+
 ## v0.35.0 (Jun 28, 2025)
+
+### Enhancements
 
  * `ClientCapabilities` fields now default to `false` when not provided in
     the API response.
@@ -14,6 +28,8 @@ No changes yet.
 
 
 ## v0.34.0 (Jun 12, 2025)
+
+### Upgrades
 
  * `tabled` was upgraded to `0.20.0`
 

--- a/README.md
+++ b/README.md
@@ -14,25 +14,25 @@ This library is relatively young, breaking API changes are possible.
 ### Blocking Client
 
 ```toml
-rabbitmq_http_client = { version = "0.35.0", features = ["core", "blocking"] }
+rabbitmq_http_client = { version = "0.36.0", features = ["core", "blocking"] }
 ```
 
 ### Async Client
 
 ```toml
-rabbitmq_http_client = { version = "0.35.0", features = ["core", "async"] }
+rabbitmq_http_client = { version = "0.36.0", features = ["core", "async"] }
 ```
 
 ### Blocking Client with Tabled Support
 
 ```toml
-rabbitmq_http_client = { version = "0.35.0", features = ["core", "blocking", "tabled"] }
+rabbitmq_http_client = { version = "0.36.0", features = ["core", "blocking", "tabled"] }
 ```
 
 ### Async Client with Tabled Support
 
 ```toml
-rabbitmq_http_client = { version = "0.35.0", features = ["core", "async", "tabled"] }
+rabbitmq_http_client = { version = "0.36.0", features = ["core", "async", "tabled"] }
 ```
 
 

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -523,9 +523,11 @@ pub struct Connection {
     pub name: String,
     /// To what node the client is connected
     pub node: String,
-    /// Connection state
-    #[serde(default = "undefined")]
-    pub state: String,
+    /// Connection state.
+    /// Regular client connections (a.k.a. network connections) will usually
+    /// have this state, while direct AMQP 0-9-1 Erlang client connections won't.
+    #[cfg_attr(feature = "tabled", tabled(display = "display_option"))]
+    pub state: Option<String>,
     /// What protocol the connection uses
     pub protocol: String,
     /// The name of the authenticated user
@@ -535,16 +537,20 @@ pub struct Connection {
     pub connected_at: u64,
     /// The hostname used to connect.
     #[serde(rename(deserialize = "host"))]
-    pub server_hostname: String,
+    #[cfg_attr(feature = "tabled", tabled(display = "display_option"))]
+    pub server_hostname: Option<String>,
     /// The port used to connect.
     #[serde(rename(deserialize = "port"))]
-    pub server_port: u32,
+    #[cfg_attr(feature = "tabled", tabled(display = "display_option"))]
+    pub server_port: Option<u32>,
     /// Client hostname.
     #[serde(rename(deserialize = "peer_host"))]
-    pub client_hostname: String,
+    #[cfg_attr(feature = "tabled", tabled(display = "display_option"))]
+    pub client_hostname: Option<String>,
     /// Ephemeral client port.
     #[serde(rename(deserialize = "peer_port"))]
-    pub client_port: u32,
+    #[cfg_attr(feature = "tabled", tabled(display = "display_option"))]
+    pub client_port: Option<u32>,
     /// Maximum number of channels that can be opened on this connection.
     #[cfg_attr(feature = "tabled", tabled(display = "display_option"))]
     pub channel_max: Option<u16>,


### PR DESCRIPTION
Direct connections in RabbitMQ are
the connections that use the "direct" connectivity option in the Erlang AMQP 0-9-1 client, that is,
rely on the Erlang distribution protocol over
a net TCP connection.

In practical terms, they are the local halves
of shovels or federation links, whereas the
remote parts use regular ("network") connections
that open new TCP connections, like any
AMQP 0-9-1 client would.

Because direct connections are not necessarily
backed by a network connection (imagine a
shovel that uses a queue with a leader
hosted on the very same node), they may or may
not have certain fields that responses::Connection was expecting.

This solution is more straightforward and less
disruptive compared to using an enum that
represents both connection types, and trying to
implement Tabled for it.

References rabbitmq/rabbitmqadmin-ng#68.