### PR TITLE
Like I don't freaking have anything better to do: a RabbitMQ 3.10.x compatibility fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Rust Client for the RabbitMQ HTTP API Change Log
 
-## v0.43.0 (in development)
+## v0.44.0 (in development)
 
 No changes yet.
+
+
+## v0.43.0 (Aug 19, 2025)
+
+### Enhancements
+
+ * `responses::VirtualHost#metadata` is now optional. It was introduced in RabbitMQ `3.8.0` in 2019
+   but for various reasons can be missing in versions up to `3.11.0` or so.
+
+   This can be considered a RabbitMQ `3.10.x` (that reached EOL in late 2023) compatibility fix.
+   Responsible adults don't run EOL versions of RabbitMQ, of course. 
 
 
 ## v0.42.0 (Aug 14, 2025)

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -482,7 +482,7 @@ pub struct VirtualHost {
     pub default_queue_type: Option<String>,
     /// All virtual host metadata combined
     #[cfg_attr(feature = "tabled", tabled(skip))]
-    pub metadata: VirtualHostMetadata,
+    pub metadata: Option<VirtualHostMetadata>,
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
There are only two justifications for doing something like this:

 * [Migrations to 4.x with Quorum Queues](https://www.rabbitmq.com/blog/2025/07/29/latest-benefits-of-rmq-and-migrating-to-qq-along-the-way) depend on this struct
 * All other metadata fields on a `VirtualHost` are already optional, so why not `metadata`

Responsible adults do not run EOL versions of RabbitMQ but they are not the only kind of adults out there.