### PR TITLE
Improve HttpClientError Display messages and documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,8 +11,8 @@ All the standard Cargo commands apply but with one important detail: make sure t
 both the async and blocking client are built, tested, linted, and so on.
 
  * `cargo build --all-features` to build
- * `cargo nextest run --all-features` to run tests
- * `cargo clippy --all-features` to lint
+ * `RUSTFLAGS="-D warnings" cargo nextest run --all-features` to run tests
+ * `RUSTFLAGS="-D warnings" cargo clippy --all-features` to lint
  * `cargo fmt` to reformat
  * `cargo publish` to publish the crate
 
@@ -50,6 +50,8 @@ Tests are consolidated into three test binaries (plus the lib unit test binary) 
  * `tests/proptests/` — property-based tests (of which `unit_*_proptests.rs` doesn't need a locally running RabbitMQ node)
 
 Each directory has a `main.rs` crate root that declares all modules.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for step-by-step Docker setup instructions for the local test environment.
 
 ### `nextest` Test Filters
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,66 @@ See also [AGENTS.md](./AGENTS.md) for a high-level codebase overview and convent
 
 ## Running Tests
 
-While tests support the standard `cargo test` option, another option
-for running tests is [cargo-nextest](https://nexte.st/).
+Most tests require a locally running RabbitMQ node. The easiest way to get one is via Docker.
 
-### `nextest` Test Filters
+### Prerequisites
+
+Install [cargo-nextest](https://nexte.st/) if you don't have it:
+
+```bash
+cargo install cargo-nextest
+```
+
+### Step 1: Start RabbitMQ
+
+```bash
+docker run -d --name rabbitmq \
+  -p 15672:15672 \
+  -p 5672:5672 \
+  rabbitmq:4.1-management
+```
+
+Wait for the node to boot:
+
+```bash
+sleep 15
+```
+
+### Step 2: Pre-configure the Node
+
+Run the setup script using the Docker exec variant of `rabbitmqctl`:
+
+```bash
+RUST_HTTP_API_CLIENT_RABBITMQCTL=DOCKER:rabbitmq bin/ci/before_build.sh
+```
+
+This enables the required plugins (management, shovel, federation, stream), creates test users,
+sets up the `rust/http/api/client` vhost, sets the cluster name, and enables all feature flags.
+
+Wait for the changes to apply:
+
+```bash
+sleep 10
+```
+
+### Step 3: Run All Tests
+
+```bash
+NEXTEST_RETRIES=3 cargo nextest run --all-features
+```
+
+`NEXTEST_RETRIES=3` retries each failing test up to 3 times. This is recommended because some
+tests depend on management plugin stats that can lag slightly behind the actual broker state.
+
+### Stopping the Node
+
+```bash
+docker stop rabbitmq && docker rm rabbitmq
+```
+
+---
+
+## `nextest` Test Filters
 
 Key [`nextest` filterset predicates](https://nexte.st/docs/filtersets/reference/):
 
@@ -20,12 +76,6 @@ Key [`nextest` filterset predicates](https://nexte.st/docs/filtersets/reference/
 
 For example, use `cargo nextest run --all-features -E 'binary(=test_module_name)'` to run
 all tests in a specific module.
-
-### Run All Tests
-
-``` bash
-NEXTEST_RETRIES=3 cargo nextest run --all-features
-```
 
 ### Run All Async Client Tests
 
@@ -75,6 +125,8 @@ cargo nextest run --all-features -E 'test(~prop_)'
 
 See the [nextest filtersets documentation](https://nexte.st/docs/selecting/) for more
 filter expression predicates and operators.
+
+---
 
 ## Running TLS Integration Tests
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,7 +29,7 @@ pub enum EndpointValidationError {
     UnsupportedScheme { endpoint: String },
 
     /// The underlying HTTP client could not be constructed.
-    #[error("failed to build HTTP client")]
+    #[error("failed to build HTTP client: {source}")]
     ClientBuildError {
         #[source]
         source: reqwest::Error,
@@ -100,20 +100,20 @@ pub enum Error<U, S, E, BT> {
         "Cannot delete a binding: multiple matching bindings were found, provide additional properties"
     )]
     MultipleMatchingBindings,
-    #[error("could not convert provided value into an HTTP header value")]
+    #[error("could not convert provided value into an HTTP header value: {error}")]
     InvalidHeaderValue { error: InvalidHeaderValue },
     #[error("Unsupported argument value for property (field) {property}")]
     UnsupportedArgumentValue { property: String },
     #[error("Missing required argument")]
     MissingProperty { argument: String },
-    #[error("Response is incompatible with the target data type")]
+    #[error("Response is incompatible with the target data type: {error}")]
     IncompatibleBody {
         error: ConversionError,
         backtrace: BT,
     },
     #[error("Could not parse a value: {message}")]
     ParsingError { message: String },
-    #[error("encountered an error when performing an HTTP request")]
+    #[error("encountered an error when performing an HTTP request: {error}")]
     RequestError { error: E, backtrace: BT },
     #[error("an unspecified error")]
     Other,

--- a/tests/unit/unit_error_tests.rs
+++ b/tests/unit/unit_error_tests.rs
@@ -147,6 +147,86 @@ fn test_user_message_other() {
 }
 
 #[test]
+fn test_display_request_error_includes_underlying_error() {
+    let err = reqwest::blocking::get("not-a-valid-url").unwrap_err();
+    let error = HttpClientError::RequestError {
+        error: err,
+        backtrace: Backtrace::new(),
+    };
+    let msg = error.to_string();
+    assert!(
+        msg.starts_with("encountered an error when performing an HTTP request:"),
+        "unexpected message: {}",
+        msg
+    );
+    assert!(
+        msg.len() > "encountered an error when performing an HTTP request:".len(),
+        "underlying error detail missing: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_display_invalid_header_value_includes_underlying_error() {
+    use reqwest::header::HeaderValue;
+    let err = HeaderValue::from_bytes(&[0x01]).unwrap_err();
+    let error = HttpClientError::InvalidHeaderValue { error: err };
+    let msg = error.to_string();
+    assert!(
+        msg.starts_with("could not convert provided value into an HTTP header value:"),
+        "unexpected message: {}",
+        msg
+    );
+    assert!(
+        msg.len() > "could not convert provided value into an HTTP header value:".len(),
+        "underlying error detail missing: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_display_incompatible_body_includes_underlying_error() {
+    use rabbitmq_http_client::error::ConversionError;
+    let error = HttpClientError::IncompatibleBody {
+        error: ConversionError::ParsingError {
+            message: "unexpected token".to_owned(),
+        },
+        backtrace: Backtrace::new(),
+    };
+    let msg = error.to_string();
+    assert!(
+        msg.contains("unexpected token"),
+        "underlying error detail missing: {}",
+        msg
+    );
+}
+
+#[test]
+fn test_display_endpoint_validation_client_build_error_includes_source() {
+    use rabbitmq_http_client::error::EndpointValidationError;
+    // An invalid PEM certificate forces reqwest::ClientBuilder::build() to fail
+    let bad_cert = reqwest::Certificate::from_pem(b"not a valid certificate");
+    if let Err(source) = bad_cert {
+        let error = EndpointValidationError::ClientBuildError { source };
+        let msg = error.to_string();
+        assert!(
+            msg.starts_with("failed to build HTTP client:"),
+            "unexpected message: {}",
+            msg
+        );
+        assert!(
+            msg.len() > "failed to build HTTP client:".len(),
+            "underlying error detail missing: {}",
+            msg
+        );
+    } else {
+        // If we can't construct the error, at least verify the message format compiles
+        // by checking the variant's Display output directly via the error type
+        panic!("expected certificate parsing to fail");
+    }
+}
+
+#[test]
 fn test_error_details_from_json() {
     let json = r#"{"error": "bad_request", "reason": "Invalid queue name"}"#;
     let details = ErrorDetails::from_json(json);


### PR DESCRIPTION
This PR improves error message quality and updates documentation for local development setup.

## Error message improvements

Several `HttpClientError` and `EndpointValidationError` variants captured useful context in their
fields but did not include it in the `Display` output:

- `RequestError`: now includes the underlying `reqwest::Error` detail
- `InvalidHeaderValue`: now includes the underlying error detail
- `IncompatibleBody`: now includes the underlying `ConversionError` detail
- `EndpointValidationError::ClientBuildError`: now includes the source error detail

Callers that display errors directly via `{}` (rather than calling `user_message()`) now see
actionable detail without needing to inspect the error source chain separately.

## Documentation

- `CONTRIBUTING.md`: added a step-by-step Docker-based local test setup guide (start RabbitMQ,
  pre-configure the node via `before_build.sh`, run the tests)
- `AGENTS.md`: added `RUSTFLAGS="-D warnings"` to the nextest and clippy commands to match CI
  strictness; added a pointer to CONTRIBUTING.md for the local test environment setup

## Tests

All error message changes are covered by new unit tests in `tests/unit/unit_error_tests.rs`.
